### PR TITLE
README PEP8 Update

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ network again, can read it from the file and we wont need to Train it again.
 my_neural_net.save( location = "net.dat" )
 ```
 
-Saves the neural network MyNeuralNet to a local file `net.dat`.
+Saves the neural network `my_neural_net` to a local file `net.dat`.
 
 
 --
@@ -156,4 +156,4 @@ my_loaded_neural_net = dendrites.NeuralNetwork()
 my_loaded_neural_net.load( location = "net.dat" )
 ```
 
-Creates a new neural network MyLoadedNeuralNet and loads it from the file `net.dat`. We can now Run MyLoadedNeuralNet and it will behave the same way the previous network (we saved to `net.dat` file) did.
+Creates a new neural network `my_loaded_neural_net` and loads it from the file `net.dat`. We can now Run `my_loaded_neural_net` and it will behave the same way the previous network (we saved to `net.dat` file) did.

--- a/README.md
+++ b/README.md
@@ -12,13 +12,13 @@ being ignored either.
 The main purpose of dendrites is to be a **ultra easy to use** neural network.
 
 **Note: This repo is heavy work in progress, but it fundamentally
-works. Every help is welcome**
+works. Any help is welcome**
 
 ---
 
 ### Requirements:
 
-Dendrites depends on only one non standard library, **numpy**.
+Dendrites depends on only one non-standard library, **numpy**.
 
 If you don't have numpy already installed, run: `sudo pip3 install numpy`.
 
@@ -53,7 +53,7 @@ my_neural_net = dendrites.NeuralNetwork( dimensions = (2,5,3) )
 
 ### Creating a NeuralNetwork object with only the number of inputs and outputs
 
-You can also create a NeralNetwork instance only by telling it how many 
+You can also create a NeuralNetwork instance only by telling it how many 
 inputs and outputs to have. This is even more simple than the previous method.
 
 ```python
@@ -64,7 +64,7 @@ my_neural_net = dendrites.NeuralNetwork( inputs = 2, outputs = 3 )
 
 The above code creates a NeuralNetwork instance with 2 inputs and 3 outputs.
 
-The neural network tries to predict how many hidden layers should it have. (*Heavy work in progress*)
+The neural network then tries to predict how many hidden layers it should have. (*Heavy work in progress*)
 
 -- 
 
@@ -94,20 +94,20 @@ my_neural_net.train()
 
 The above code instructs our network to train itself.
 
-**By default** the network trains until the difference between the way
-it behaves and the way we specified it to behave (with providing supervised dataset)
-is less than **1%**.
+**By default** the network trains until the percent difference between the way
+it behaves and the way we specified it to behave (according to the provided
+supervised dataset) is less than **1%**.
 
 
-If we want, for some reason, for our network to train itself until the margin (error) is
-under **10%**, we would write:
+If we want, for some reason, for our network to train itself until the difference margin
+(error) is under **10%**, we would write:
 ```python
 my_neural_net.train( margin = 0.1 )
 ```
 
 
-Also, we could also want for out network to train until the margin (error) is virtually zero.
-Then, we would write:
+Also, we could also want for out network to train until the difference margin (error)
+is virtually zero. Then, we would write:
 
 ```python
 my_neural_net.train( force_convergence = True )
@@ -125,17 +125,20 @@ output = my_neural_net.run( input = [0,1] )
 print( output )
 ```
 
-we bring `0 , 1` to the input of our network. The network output is also a list, with the dimensions we specified earlier.
+we bring `0 , 1` to the input of our network.
+The network output is also a list, with the dimensions we specified earlier.
 
 
-*Note*: you can Run your network before you have trained it. However, the network will give out a random result, because every time you create a network, the synapse nodes are initiated with random weights.
+*Note*: you can `run` your network before you have trained it.
+However, the network will give out a random result, because every time you create a network, 
+the synapse nodes are initiated with random weights.
 
 --
 
 ###Saving the network to a file
 
-When we trained our network, we can save it to a file. This way if we wanted to use our
-network again, can read it from the file and we wont need to Train it again.
+When we have finished training our network, we can save it to a file. This way if we wanted to
+use our network again, it can be read from the file and we wont need to `train` it again.
 
 ```python
 my_neural_net.save( location = "net.dat" )
@@ -156,4 +159,4 @@ my_loaded_neural_net = dendrites.NeuralNetwork()
 my_loaded_neural_net.load( location = "net.dat" )
 ```
 
-Creates a new neural network `my_loaded_neural_net` and loads it from the file `net.dat`. We can now Run `my_loaded_neural_net` and it will behave the same way the previous network (we saved to `net.dat` file) did.
+Creates a new neural network `my_loaded_neural_net` and loads it from the file `net.dat`. We can now `run` `my_loaded_neural_net` and it will behave the same way the previous network (saved to the `net.dat` file) did.

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Therefore, our network has 2 inputs and 3 outputs.
 
 If we wanted a third, *"middle"* layer with 5 nodes, we would write:
 ```python
-my_neural_net = dendrites.NeuralNetwork( dimensions = ( 2,5,3) )
+my_neural_net = dendrites.NeuralNetwork( dimensions = (2,5,3) )
 ```
 
 --

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ If you don't have numpy already installed, run: `sudo pip3 install numpy`.
 ```python
 import dendrites
 
-MyNeuralNet = dendrites.NeuralNetwork( dimensions = (2,3) )
+my_neural_net = dendrites.NeuralNetwork( dimensions = (2,3) )
 ```
 
 This code creates a NeuralNetwork instance.
@@ -44,7 +44,7 @@ Therefore, our network has 2 inputs and 3 outputs.
 
 If we wanted a third, *"middle"* layer with 5 nodes, we would write:
 ```python
-MyNeuralNet = dendrites.NeuralNetwork( dimensions = ( 2,5,3) )
+my_neural_net = dendrites.NeuralNetwork( dimensions = ( 2,5,3) )
 ```
 
 --
@@ -57,7 +57,7 @@ inputs and outputs to have. This is even more simple than the previous method.
 ```python
 import dendrites
 
-MyNeuralNet = dendrites.NeuralNetwork( inputs = 2, outputs = 3 )
+my_neural_net = dendrites.NeuralNetwork( inputs = 2, outputs = 3 )
 ```
 
 The above code creates a NeuralNetwork instance with 2 inputs and 3 outputs.
@@ -75,7 +75,7 @@ In this example, lets use the NeuralNetwork instance with 2 inputs and 3 outputs
 Lets instruct it to bring `0 , 1 , 0` to output when `0 , 1` is brought to input.
 
 ```python
-MyNeuralNet.Add( input = [0,1], output = [0,1,0] )
+my_neural_net.add( input = [0,1], output = [0,1,0] )
 ```
 
 --
@@ -87,7 +87,7 @@ Lets say we added a supervised dataset to our network. But we can't run our netw
 we have to train it first. Training is the part in which the network *learns*.
 
 ```python
-MyNeuralNet.Train()
+my_neural_net.train()
 ```
 
 The above code instructs our network to train itself.
@@ -100,7 +100,7 @@ is less than **1%**.
 If we want, for some reason, for our network to train itself until the margin (error) is
 under **10%**, we would write:
 ```python
-MyNeuralNet.Train( margin = 0.1 )
+my_neural_net.train( margin = 0.1 )
 ```
 
 
@@ -108,7 +108,7 @@ Also, we could also want for out network to train until the margin (error) is vi
 Then, we would write:
 
 ```python
-MyNeuralNet.Train( force_convergence = True )
+my_neural_net.train( force_convergence = True )
 ```
 
 This is not recommended, as it can take a really long time for the network to train this way.
@@ -119,7 +119,7 @@ This is not recommended, as it can take a really long time for the network to tr
 
 By running:
 ```python
-output = MyNeuralNet.Run( input = [0,1] )
+output = my_neural_net.run( input = [0,1] )
 print( output )
 ```
 
@@ -136,7 +136,7 @@ When we trained our network, we can save it to a file. This way if we wanted to 
 network again, can read it from the file and we wont need to Train it again.
 
 ```python
-MyNeuralNet.Save( location="net.dat" )
+my_neural_net.save( location = "net.dat" )
 ```
 
 Saves the neural network MyNeuralNet to a local file `net.dat`.
@@ -148,8 +148,8 @@ Saves the neural network MyNeuralNet to a local file `net.dat`.
 ###Reading the network from a file
 
 ```python
-MyLoadedNeuralNet = dendrites.NeuralNetwork()
-MyLoadedNeuralNet.Load( location="net.dat" )
+my_loaded_neural_net = dendrites.NeuralNetwork()
+my_loaded_neural_net.load( location = "net.dat" )
 ```
 
 Creates a new neural network MyLoadedNeuralNet and loads it from the file `net.dat`. We can now Run MyLoadedNeuralNet and it will behave the same way the previous network (we saved to `net.dat` file) did.

--- a/README.md
+++ b/README.md
@@ -44,6 +44,8 @@ Therefore, our network has 2 inputs and 3 outputs.
 
 If we wanted a third, *"middle"* layer with 5 nodes, we would write:
 ```python
+import dendrites
+
 my_neural_net = dendrites.NeuralNetwork( dimensions = (2,5,3) )
 ```
 

--- a/README.md
+++ b/README.md
@@ -150,6 +150,8 @@ Saves the neural network MyNeuralNet to a local file `net.dat`.
 ###Reading the network from a file
 
 ```python
+import dendrites
+
 my_loaded_neural_net = dendrites.NeuralNetwork()
 my_loaded_neural_net.load( location = "net.dat" )
 ```


### PR DESCRIPTION
Updates the README file to match the recent changes made to the naming convention of methods.

In the examples, methods and variables now use the lower_case_with_underscores naming convention as opposed to UpperCamelCase, as was used previously.

Also removed one space and added an import for the library whenever it was used so the instructions are more consistent.

Update: Fixed some grammar in the README, there may still be more minor errors left. It would be safest to read through once and see if you can catch any I might have missed before this is merged.